### PR TITLE
docs: add architecture diagram for control/execution/data/safety planes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,42 @@ Rule of thumb: **if it isn't linked to `runId/taskId` and written to logs, it di
 
 ## Architecture
 
-```text
-[Omniscience UI/API]
-        |
-        | (events/ops adapters)
-        v
- [OpenClaw Runtime]
-        |
-        v
- [Postgres: tasks, activities, timeline_events, audit_logs]
+```mermaid
+flowchart TB
+      User[User / API Client]
+
+      subgraph ControlPlane[Control Plane]
+          UI[Omniscience UI]
+          API[Dashboard API]
+          Policy[Policy Checks & Trace UX]
+      end
+
+      subgraph ExecutionPlane[Execution Plane]
+          OpenClaw[OpenClaw Runtime]
+          Agents[Tools / Sessions / Retries]
+      end
+
+      subgraph DataPlane[Data Plane]
+          DB[(Postgres)]
+          Tables[tasks · activities · timeline_events · audit_logs]
+      end
+
+      subgraph SafetyPlane[Safety Plane]
+          Approvals[Approval Gates]
+          Audit[Audit Logging]
+      end
+
+      User --> UI
+      UI --> API
+      API --> OpenClaw
+      OpenClaw --> Agents
+
+      OpenClaw --> DB
+      DB --> Tables
+
+      API --> Policy
+      Policy --> Approvals
+      OpenClaw --> Audit
 ```
 
 Layers:

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,35 @@
+flowchart TB
+    User[User / API Client]
+
+    subgraph ControlPlane[Control Plane]
+        API[Dashboard API]
+        Scheduler[Task Scheduler]
+    end
+
+    subgraph ExecutionPlane[Execution Plane]
+        Dispatcher[Task Dispatcher]
+        Agents[Execution Agents]
+    end
+
+    subgraph DataPlane[Data Plane]
+        DB[(Metadata DB)]
+        Logs[(Logs & Metrics)]
+    end
+
+    subgraph SafetyPlane[Safety Plane]
+        Auth[AuthN / AuthZ]
+        Audit[Audit & Policy Engine]
+    end
+
+    User --> API
+    API --> Scheduler
+    Scheduler --> Dispatcher
+    Dispatcher --> Agents
+
+    Agents --> Logs
+    Scheduler --> DB
+
+    API --> Auth
+    Dispatcher --> Audit
+
+    DB --> Audit


### PR DESCRIPTION
## What changed

- Added a Mermaid architecture diagram to the README
- Visualized control, execution, data, and safety planes
- Replaced the previous ASCII architecture sketch with a clearer diagram

## Why

The architecture diagram makes system boundaries and responsibilities easier
to understand for new contributors and operators, improving onboarding and
reasoning about the platform.

## How to verify

- [x] `npm run build`
- [x] Relevant documentation renders correctly in README

- [ ] screenshots attached (not applicable; docs-only change)

## Risk

- [x] low
- [ ] medium
- [ ] high

## Ops / migration notes

No operational, database, or deployment changes. Documentation-only update.

